### PR TITLE
change commonConfig to function invocation

### DIFF
--- a/manuscript/developing/02_automatic_browser_refresh.md
+++ b/manuscript/developing/02_automatic_browser_refresh.md
@@ -175,7 +175,7 @@ const developmentConfig = () => {
 
   return Object.assign(
     {},
-    commonConfig,
+    commonConfig(),
     config
   );
 };


### PR DESCRIPTION
Was going through the tutorial and the instructions didn't work.  I _think_ it's because commonConfig is a function and not returning the object needed for webpack to run.  Not sure if anyone else had this problem.

```javascript

const path = require('path');
const HtmlWebpackPlugin = require('html-webpack-plugin');

const PATH = {
	src: path.join(__dirname, 'src'),
	build: path.join(__dirname, 'build')
}

const commonConfig = () => {
	console.log('PATH.src',PATH.src);
		return {
			entry: PATH.src,
			output: {
			filename: 'bundle.js',
			path: PATH.build
		},
			plugins: [
				new HtmlWebpackPlugin({
					title: 'Base Template'
				})
			]
		}
}


// const productionConfig = () => commonConfig;
const developementConfig = () => {
	const config = {
		devServer: {
			historyApiFallback: true,
			stats: 'errors-only',
			host: process.env.HOST,
			port: process.env.PORT
		}
	};

	return Object.assign(
    {},
    commonConfig(),
    config
  );
}

module.exports = (env) => {
	if (env === 'production') {
    return productionConfig();
  }
	return developementConfig();
}
```

now works.  Without the function call I was getting: Configuration file found but no entry configured. Which made sense because that commonconfig object wasn't there.